### PR TITLE
Support more than one custom SCSS file.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="django-simple-bulma",
-    version="2.2.1",
+    version="2.3.1",
     description="Django application to add the Bulma CSS framework and its extensions",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This is such a stupid error, I was removing the SimpleBulmaFinder from the list of finders inside a loop, so whenever there were more than one custom SCSS files, it would just crash.

Cleaned that up now, and restructured the file a little.