### PR TITLE
Enable Django 5.2 compatibility

### DIFF
--- a/django_simple_bulma/finders.py
+++ b/django_simple_bulma/finders.py
@@ -197,16 +197,19 @@ class SimpleBulmaFinder(BaseFinder):
 
         return paths
 
-    def find(self, path: str, all: bool = False) -> Union[List[str], str]:
+    def find(self, path: str, find_all: bool = False, all: bool = False) -> Union[List[str], str]:
         """
         Given a relative file path, find an absolute file path.
 
-        If the ``all`` parameter is False (default) return only the first found
-        file path; if True, return a list of all found files paths.
+        Django 5.2 uses the ``find_all` instead of the ``all`` keyword argument.
+
+        If the ``find_all`` or ``all`` parameter is False (default) return only
+        the first found file path; if True, return a list of all found files
+        paths.
         """
         absolute_path = str(simple_bulma_path / path)
 
-        if all:
+        if find_all or all:
             return [absolute_path]
         return absolute_path
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="django-simple-bulma",
-    version="2.6.0",
+    version="2.7.0",
     description="Django application to add the Bulma CSS framework and its extensions",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="django-simple-bulma",
-    version="2.7.0",
+    version="2.6.0",
     description="Django application to add the Bulma CSS framework and its extensions",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Response to #104, and inspired by #107.

This PR is intended to not break any existing functionality and compatibility. It merely adds the `find_all` kwarg used by Django 5.2 to `SimpleBulmaFinder.find` method. It does not replace the `all` kwarg, so that can still be used for earlier Django versions.

In `setup.py` I have only done a minor version bump to `2.7.0`.

I have not changed anything else, because I hope this can be merged quickly. 