### PR TITLE
Fix CSS build consistency and JS timing issues

### DIFF
--- a/django_simple_bulma/finders.py
+++ b/django_simple_bulma/finders.py
@@ -56,7 +56,8 @@ class SimpleBulmaFinder(BaseFinder):
         """Return a string that, in SASS, imports all enabled extensions."""
         scss_imports = ""
 
-        for ext in (simple_bulma_path / "extensions").iterdir():
+        # Load extensions in alphabetical order (deterministic and no interdependencies)
+        for ext in sorted((simple_bulma_path / "extensions").iterdir()):
 
             if is_enabled(ext):
                 for src in get_sass_files(ext):
@@ -201,7 +202,8 @@ class SimpleBulmaFinder(BaseFinder):
         """
         extension_css_parts = []
 
-        for ext_dir in (simple_bulma_path / "extensions").iterdir():
+        # Process extensions in alphabetical order for deterministic CSS generation
+        for ext_dir in sorted((simple_bulma_path / "extensions").iterdir()):
             if is_enabled(ext_dir):
                 # Look for CSS files in the extension
                 dist_dir = ext_dir / "dist"
@@ -237,14 +239,22 @@ class SimpleBulmaFinder(BaseFinder):
 
         bulma_string = f"@import '{sass_bulma_submodule_path}/utilities/_index';\n"
 
-        # Now load bulma dynamically.
-        for dirname in self.bulma_submodule_path.iterdir():
+        # Load Bulma modules in the official order (from bulma/sass/_index.scss)
+        # Note: utilities is already loaded above
+        bulma_module_order = [
+            "themes", "base", "elements", "form", "components",
+            "grid", "layout", "helpers"
+        ]
 
-            # We already added this earlier
-            if dirname.name == "utilities":
-                continue
+        for module_name in bulma_module_order:
+            module_path = self.bulma_submodule_path / module_name
+            if module_path.exists():
+                bulma_string += f"@import '{sass_bulma_submodule_path}/{module_name}/_index';\n"
 
-            bulma_string += f"@import '{sass_bulma_submodule_path}/{dirname.name}/_index';\n"
+        # Handle base/skeleton separately as it's loaded after layout in the official order
+        skeleton_path = self.bulma_submodule_path / "base" / "skeleton.sass"
+        if skeleton_path.exists():
+            bulma_string += f"@import '{sass_bulma_submodule_path}/base/skeleton';\n"
 
         # Now load in the extensions that the user wants
         extensions_string = self._get_extension_imports()
@@ -295,7 +305,7 @@ class SimpleBulmaFinder(BaseFinder):
                     break
 
             # Raise an error if we can't find it.
-            if absolute_path is None:
+            if not absolute_path:
                 raise ValueError(
                     f"Unable to locate the SCSS file \"{scss_path}\". Make sure the file exists, "
                     "and ensure that one of the other configured Finders are able to locate it. \n"

--- a/django_simple_bulma/templatetags/django_simple_bulma.py
+++ b/django_simple_bulma/templatetags/django_simple_bulma.py
@@ -50,8 +50,18 @@ def bulma(theme: str = "", *, include_js: bool = True) -> SafeString:
 
     # Build html to include all the js files required.
     if include_js:
-        for js_file in map(static, get_js_files()):
-            html.append(f'<script defer type="text/javascript" src="{js_file}"></script>')
+        js_files = list(map(static, get_js_files()))
+        if js_files:
+            # Load scripts after DOM is ready to ensure extensions can find their target elements
+            html.append('<script type="text/javascript">')
+            html.append('document.addEventListener("DOMContentLoaded", function() {')
+            for js_file in js_files:
+                html.append('    var script = document.createElement("script");')
+                html.append(f'    script.src = "{js_file}";')
+                html.append('    script.type = "text/javascript";')
+                html.append('    document.head.appendChild(script);')
+            html.append('});')
+            html.append('</script>')
 
     return mark_safe("\n".join(html))
 

--- a/django_simple_bulma/utils.py
+++ b/django_simple_bulma/utils.py
@@ -84,7 +84,8 @@ def get_js_files() -> Generator[str, None, None]:
     """Yield all the js files that are needed for the users selected extensions."""
     # For every extension...
     extensions = []
-    for ext in (simple_bulma_path / "extensions").iterdir():
+    # Process extensions in alphabetical order for deterministic behavior
+    for ext in sorted((simple_bulma_path / "extensions").iterdir()):
         # ...check if it is enabled...
         if is_enabled(ext):
             dist_folder = ext / "dist"


### PR DESCRIPTION
- 🎲 **Extensions and Bulma modules now load in the correct, deterministic order** instead of random filesystem order. This should prevent rng inconsistencies between builds.

- ⌛ **Extension scripts now wait for `DOMContentLoaded`** instead of using `defer`, preventing race conditions where scripts run before DOM elements exist.

- 🔥 **Missing custom SCSS file now throw 'ValueError'** instead of the unhelpful `sass.CompileError` it was throwing before.

---

Fixes #98, #80, #92