### PR TITLE
Improve release workflow with git-auto-commit-action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,15 +13,13 @@ jobs:
     name: Bump version in repository
     runs-on: ubuntu-latest
     needs: check-submodules
-    permissions:
-      contents: write
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
         submodules: recursive
-        token: ${{ secrets.GITHUB_TOKEN }}
+        ssh-key: ${{ secrets.SSH_DEPLOY_KEY }}
         ref: main
 
     - name: Install UV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,7 @@ jobs:
       with:
         submodules: recursive
         token: ${{ secrets.GITHUB_TOKEN }}
-        # Checkout the default branch, not the release tag
-        ref: ${{ github.event.repository.default_branch }}
+        ref: main
 
     - name: Install UV
       uses: astral-sh/setup-uv@v4
@@ -48,12 +47,10 @@ jobs:
         uv version ${{ steps.get_version.outputs.VERSION }}
 
     - name: Commit version bump
-      run: |
-        git config --local user.email "action@github.com"
-        git config --local user.name "GitHub Action"
-        git add pyproject.toml
-        git commit -m "🔖 bump version to ${{ steps.get_version.outputs.VERSION }}"
-        git push origin ${{ github.event.repository.default_branch }}
+      uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        file_pattern: pyproject.toml
+        commit_message: "🔖 bump version to ${{ steps.get_version.outputs.VERSION }}"
 
   publish-to-pypi:
     name: Build and publish to PyPI
@@ -65,8 +62,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: recursive
-        # Fetch the latest commit (including the version bump)
-        ref: ${{ github.event.repository.default_branch }}
+        ref: main
 
     - name: Install UV
       uses: astral-sh/setup-uv@v4


### PR DESCRIPTION
## 🔧 Further improvement to release workflow

Building on the previous fix, this adopts the proven pattern from the blackbox repository which works perfectly.

## 🛠️ Changes

**Use git-auto-commit-action**: Replace manual git commands with `stefanzweifer/git-auto-commit-action@v4` which handles edge cases automatically.

**Explicit main branch**: Use `ref: main` instead of dynamic default branch references.

**Simplified logic**: Remove complex manual git handling in favor of the proven action.

This follows the exact pattern from `lemonsaurus/blackbox` which works reliably.