### PR TITLE
Use SSH deploy key for reliable release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,15 +13,13 @@ jobs:
     name: Bump version in repository
     runs-on: ubuntu-latest
     needs: check-submodules
-    permissions:
-      contents: write
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
         submodules: recursive
-        token: ${{ secrets.GITHUB_TOKEN }}
+        ssh-key: ${{ secrets.SSH_DEPLOY_KEY }}
         ref: main
 
     - name: Install UV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,7 @@ jobs:
       with:
         submodules: recursive
         token: ${{ secrets.GITHUB_TOKEN }}
-        # Checkout the default branch, not the release tag
-        ref: ${{ github.event.repository.default_branch }}
+        ref: main
 
     - name: Install UV
       uses: astral-sh/setup-uv@v4
@@ -48,12 +47,10 @@ jobs:
         uv version ${{ steps.get_version.outputs.VERSION }}
 
     - name: Commit version bump
-      run: |
-        git config --local user.email "action@github.com"
-        git config --local user.name "GitHub Action"
-        git add pyproject.toml
-        git commit -m "🔖 bump version to ${{ steps.get_version.outputs.VERSION }}"
-        git push origin ${{ github.event.repository.default_branch }}
+      uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        file_pattern: pyproject.toml
+        commit_message: "🔖 bump version to ${{ steps.get_version.outputs.VERSION }}"
 
   publish-to-pypi:
     name: Build and publish to PyPI
@@ -65,8 +62,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: recursive
-        # Fetch the latest commit (including the version bump)
-        ref: ${{ github.event.repository.default_branch }}
+        ref: main
 
     - name: Install UV
       uses: astral-sh/setup-uv@v4


### PR DESCRIPTION
## 🔧 Final fix for release workflow

Uses SSH deploy key authentication like the proven blackbox repository pattern.

## 🛠️ Changes

**SSH Deploy Key**: Replace `GITHUB_TOKEN` with `SSH_DEPLOY_KEY` for reliable push/commit permissions

**Simplified auth**: Remove unnecessary `permissions` section since SSH key handles all authentication

**Proven pattern**: Matches the exact working setup from `lemonsaurus/blackbox`

## 📋 Setup Required

After merging, you'll need to:

1. Generate SSH key pair: `ssh-keygen -t ed25519 -C "github-actions-deploy"`
2. Add public key to repo Settings → Deploy keys (with write access)  
3. Add private key to repo Settings → Secrets → `SSH_DEPLOY_KEY`

Then the release workflow will work reliably\!