### PR TITLE
🔧 chore: switch PyPI release to OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,18 @@ jobs:
     name: Check submodules
     uses: ./.github/workflows/check-submodules.yml
 
-  bump-version:
-    name: Bump version in repository
+  release:
+    name: Bump version, build, and publish
     runs-on: ubuntu-latest
     needs: check-submodules
+    environment: pypi
+
+    # `id-token: write` lets the publish step mint the OIDC token PyPI
+    # trusts for this repo + workflow + environment. `contents: write`
+    # is for the auto-commit that pushes the version bump back to main.
+    permissions:
+      id-token: write
+      contents: write
 
     steps:
     - name: Checkout repository
@@ -31,51 +39,25 @@ jobs:
     - name: Set up Python
       run: uv python install 3.13
 
-    - name: Get version from release tag
-      id: get_version
+    - name: Resolve version from release tag
+      id: version
       run: |
-        # Remove 'v' prefix if present from the release tag
         VERSION=${{ github.event.release.tag_name }}
+        # Strip leading 'v' if present
         VERSION=${VERSION#v}
-        echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
-        echo "Release version: $VERSION"
+        echo "value=$VERSION" >> "$GITHUB_OUTPUT"
 
-    - name: Update version in pyproject.toml
-      run: |
-        uv version ${{ steps.get_version.outputs.VERSION }}
+    - name: Bump version in pyproject.toml
+      run: uv version "${{ steps.version.outputs.value }}"
 
-    - name: Commit version bump
-      uses: stefanzweifel/git-auto-commit-action@v4
-      with:
-        file_pattern: pyproject.toml
-        commit_message: "🔖 bump version to ${{ steps.get_version.outputs.VERSION }}"
-
-  publish-to-pypi:
-    name: Build and publish to PyPI
-    runs-on: ubuntu-latest
-    needs: bump-version
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-      with:
-        submodules: recursive
-        ref: main
-
-    - name: Install UV
-      uses: astral-sh/setup-uv@v4
-      with:
-        enable-cache: true
-        cache-dependency-glob: "pyproject.toml"
-
-    - name: Set up Python
-      run: uv python install 3.13
-
-    - name: Build package
+    - name: Build distribution
       run: uv build
 
-    - name: Publish to PyPI
-      run: |
-        uv publish \
-          --username __token__ \
-          --password ${{ secrets.PYPI_TOKEN }}
+    - name: Commit version bump
+      uses: stefanzweifel/git-auto-commit-action@v5
+      with:
+        file_pattern: pyproject.toml
+        commit_message: "🔖 bump version to ${{ steps.version.outputs.value }}"
+
+    - name: Publish to PyPI via Trusted Publishing
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
> [!WARNING]
> Once a release run succeeds end-to-end, the \`PYPI_TOKEN\` secret can be deleted from repo settings. Until then, leave it in place as a safety net.

## What

Migrates `release.yml` off the long-lived `PYPI_TOKEN` secret and onto **PyPI Trusted Publishing** (OIDC).

## Why

| before | after |
| --- | --- |
| `uv publish --username __token__ --password \${{ secrets.PYPI_TOKEN }}` | `pypa/gh-action-pypi-publish@release/v1` mints a short-lived OIDC token at run time |
| Token has to be rotated manually if it ever leaks | No token to leak; trust is scoped to repo + workflow + environment by PyPI |
| Two jobs, two checkouts, two UV installs | One \`release\` job |

The PyPI side is already configured (Trusted Publisher: lemonsaurus / django-simple-bulma / release.yml / environment \`pypi\`).

## What changed in the workflow

- Collapsed \`bump-version\` and \`publish-to-pypi\` into a single \`release\` job. Same steps, half the boilerplate.
- Added \`environment: pypi\` so the publish step is gated by the GitHub environment PyPI is matching against.
- Added \`permissions: id-token: write\` (required for OIDC) and \`contents: write\` (the auto-commit needs it now that we're not relying solely on the deploy key).
- Bumped \`stefanzweifel/git-auto-commit-action\` v4 → v5.
- Renamed step IDs/outputs for clarity (\`get_version\` → \`version\`, \`VERSION\` → \`value\`).